### PR TITLE
chore: enable symfony 6 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
-        symfony-version: ['^4.4', '^5.0']
+        php-version: ['8.1']
+        symfony-version: ['^6.1']
     steps:
       - uses: actions/checkout@master
       - uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -9,16 +9,15 @@
         }
     ],
     "require" : {
-        "php" : ">=7.2",
+        "php" : ">=8.1",
         "ext-pcntl" : "*",
-        "psr/event-dispatcher": "^1.0",
-        "symfony/console" : "~4.4 || ~5.0",
-        "symfony/framework-bundle" : "~4.4 || ~5.0",
-        "symfony/yaml": "~4.4 || ~5.0",
+        "psr/event-dispatcher": ">=1.0",
+        "symfony/console" : "~6.1",
+        "symfony/framework-bundle" : "~6.1",
+        "symfony/yaml": "~6.1",
         "react/event-loop": "@stable"
     },
     "require-dev" : {
-        "sensiolabs/security-checker": "^6.0",
         "phpunit/phpunit": "^8.4"
     },
     "autoload" : {
@@ -26,9 +25,6 @@
             "M6Web\\Bundle\\DaemonBundle\\" : "src/",
             "M6Web\\Bundle\\DaemonBundle\\Tests\\": "tests/"
         }
-    },
-    "conflict": {
-        "symfony/event-dispatcher": "<4.4"
     },
     "extra": {
         "branch-alias": {

--- a/src/Command/DaemonCommand.php
+++ b/src/Command/DaemonCommand.php
@@ -123,9 +123,9 @@ abstract class DaemonCommand extends Command
      * Define command code callback.
      *
      * @param callable $callback
-     * @return DaemonCommand
+     * @return $this
      */
-    public function setCode(callable $callback): DaemonCommand
+    public function setCode(callable $callback): static
     {
         $this->loopCallback = $callback;
 


### PR DESCRIPTION
Least effort try to ensure the use of the bundle in a symfony 6+ environment. : 
- set symfony version to 6+ in composer.json and ensure dependencies compatibility
- modify source code where we are  forced to do it (eg. method static type required by symfony 6 Command Bundle and only compatible with PHP8+ version)

As symfony6 requires PHP 8+ we had to create a new dedicated release of this Bundle.

