### PR TITLE
chore: add symfo54 backaward compatibility with php74 and 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        php-version: [ '7.2', '7.3', '7.4', '8.0', '8.1' ]
-        symfony-version: ['^4.4', '^5.0']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1']
+        symfony-version: ['^4.4', '^5.0', '^5.4']
     steps:
       - uses: actions/checkout@master
       - uses: shivammathur/setup-php@v2

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require" : {
-        "php" : ">=7.2",
+        "php" : "~7.2 || ^8.0 || ^8.1",
         "ext-pcntl" : "*",
         "psr/event-dispatcher": "^1.0",
         "symfony/console" : "~4.4 || ~5.0",


### PR DESCRIPTION
## Why?
I need to use this bundle into a project that requires PHP 8 and Symfony 5.4

## How?
- Start from this bundle release 6.0.0 and just add php 8 support
- Change the gha test workflows to include tests of multiple versions of PHP and Symfony

## Note
I plan to release this branch to version 6.1.0 but feel free to suggest an alternative.